### PR TITLE
Fix stability of live intensity plot

### DIFF
--- a/Code/PyQt_Testing_live_ui.py
+++ b/Code/PyQt_Testing_live_ui.py
@@ -120,16 +120,25 @@ class LiveImageWindow(QtWidgets.QWidget):
         # layout.addWidget(Color('red'))
 
         # Matplotlib canvas for intensity plot
-        # self._figure = Figure(figsize=(5, 2))
-        # self._canvas = FigureCanvas(self._figure)
-        # self._axes = self._figure.add_subplot(111)
-        # self._axes.set_title("Live Intensity")
-        # self._axes.set_xlabel("Frame")
-        # self._axes.set_ylabel("Mean Intensity")
-        # self._axes.grid(True, linestyle="--", alpha=0.3)
-        # self._intensity_history = collections.deque(maxlen=300)
-        # (self._intensity_line,) = self._axes.plot([], [], color="tab:orange")
-        # layout.addWidget(self._canvas)
+        self._figure = Figure(figsize=(5, 2), constrained_layout=True)
+        self._canvas = FigureCanvas(self._figure)
+        self._canvas.setParent(self)
+        self._axes = self._figure.add_subplot(111)
+        self._axes.set_title("Live Intensity")
+        self._axes.set_xlabel("Frame")
+        self._axes.set_ylabel("Mean Intensity")
+        self._axes.grid(True, linestyle="--", alpha=0.3)
+        self._intensity_history = collections.deque(maxlen=300)
+        self._frame_index = 0
+        (self._intensity_line,) = self._axes.plot([], [], color="tab:orange")
+        self._axes.set_ylim(0, 255)
+        self._axes.set_xlim(0, 1)
+        self._plot_needs_redraw = False
+        self._plot_timer = QtCore.QTimer(self)
+        self._plot_timer.setInterval(100)
+        self._plot_timer.timeout.connect(self._refresh_intensity_plot)
+        self._plot_timer.start()
+        layout.addWidget(self._canvas)
         print('added canvas to layout')
         self.setLayout(layout)
         
@@ -172,6 +181,45 @@ class LiveImageWindow(QtWidgets.QWidget):
 
         self.image_label.setPixmap(pix)
         self.image_label.resize(pix.size())
+
+        self._record_intensity(image_array)
+
+    def _record_intensity(self, image_array: np.ndarray):
+        mean_intensity = float(np.mean(image_array))
+        self._intensity_history.append(mean_intensity)
+        self._frame_index += 1
+        self._plot_needs_redraw = True
+
+    def _refresh_intensity_plot(self):
+        if not self._plot_needs_redraw:
+            return
+
+        y = np.array(self._intensity_history, dtype=float)
+        history_len = len(y)
+        if history_len:
+            start_idx = max(0, self._frame_index - history_len)
+            x = np.arange(start_idx, start_idx + history_len)
+        else:
+            x = np.array([])
+
+        self._intensity_line.set_data(x, y)
+
+        if history_len > 0:
+            y_min = float(np.min(y))
+            y_max = float(np.max(y))
+            pad = max(1.0, (y_max - y_min) * 0.1)
+            lower = max(0.0, y_min - pad)
+            upper = min(255.0, y_max + pad)
+            if lower == upper:
+                upper = lower + 1.0
+            self._axes.set_ylim(lower, upper)
+            self._axes.set_xlim(start_idx, max(start_idx + 1, self._frame_index))
+        else:
+            self._axes.set_xlim(0, 1)
+            self._axes.set_ylim(0, 1)
+
+        self._canvas.draw_idle()
+        self._plot_needs_redraw = False
         
 
 
@@ -462,7 +510,9 @@ class MyWidget(QtWidgets.QWidget):
 
         # Start live worker
         self.live_worker = LiveViewWorker(target_hz=30.0)
-        self.live_worker.new_frame.connect(self.live_window.update_image)
+        self.live_worker.new_frame.connect(
+            self.live_window.update_image, QtCore.Qt.QueuedConnection
+        )
         self.live_window.show()
         self.live_worker.start()
         print('starting live viewing stream')
@@ -495,7 +545,9 @@ class MyWidget(QtWidgets.QWidget):
         # Ensure live window is visible and receives frames
         if not self.live_window.isVisible():
             self.live_window.show()
-        worker.new_frame.connect(self.live_window.update_image)
+        worker.new_frame.connect(
+            self.live_window.update_image, QtCore.Qt.QueuedConnection
+        )
 
     @QtCore.Slot()
     def start_rheed_stream(self, duration_s: float, freq_hz: float):


### PR DESCRIPTION
## Summary
- throttle the intensity plot redraws with a QTimer so updates occur in the GUI thread and at a steady cadence
- mark frame-delivery signal connections as queued to guarantee UI updates stay on the main thread

## Testing
- python -m compileall Code

------
https://chatgpt.com/codex/tasks/task_e_68d19eaea72883288568362e8f6733ea